### PR TITLE
Update to swift-module v2 and use of openstack application credentials

### DIFF
--- a/src/project_pusher/go.mod
+++ b/src/project_pusher/go.mod
@@ -1,0 +1,8 @@
+module project-pusher
+
+go 1.18
+
+require (
+	github.com/ncw/swift/v2 v2.0.1
+	github.com/oquinena/wpauswiftcommons v0.0.1
+)

--- a/src/project_pusher/go.mod
+++ b/src/project_pusher/go.mod
@@ -4,5 +4,5 @@ go 1.18
 
 require (
 	github.com/ncw/swift/v2 v2.0.1
-	github.com/oquinena/wpauswiftcommons v0.0.1
+	github.com/FAST2/wpauswiftcommons v0.0.1
 )

--- a/src/project_pusher/project_pusher.go
+++ b/src/project_pusher/project_pusher.go
@@ -1,27 +1,23 @@
 package main
 
 import (
+	"context"
 	"fmt"
-
-	"github.com/ncw/swift"
-	//"crypto/md5"
-	//"io/ioutil"
-	//"encoding/hex"
 	"os"
-	//"path/filepath"
-	//"bytes"
-	//"encoding/json"
-	"github.com/fast2/wpauswiftcommons"
+
+	swift "github.com/ncw/swift/v2"
+	"github.com/oquinena/wpauswiftcommons"
 )
 
 func main() {
+	ctx := context.Background()
 	// Create a connection
-	c := swift.Connection{
+	c := &swift.Connection{
 		UserName: os.Getenv("SWIFT_API_USER"),
 		ApiKey:   os.Getenv("SWIFT_API_KEY"),
 		AuthUrl:  os.Getenv("SWIFT_AUTH_URL"),
 		Domain:   os.Getenv("SWIFT_API_DOMAIN"), // Name of the domain (v3 auth only)
-		Tenant:   os.Getenv("SWIFT_TENANT"), // Name of the tenant (v2 auth only)
+		Tenant:   os.Getenv("SWIFT_TENANT"),     // Name of the tenant (v2 auth only)
 	}
 
 	if len(os.Args) < 3 {
@@ -38,21 +34,21 @@ func main() {
 	container_name := "project-" + project
 
 	// Authenticate
-	err := c.Authenticate()
+	err := c.Authenticate(ctx)
 	if err != nil {
 		panic(err)
 	}
 
 	files := os.Args[2:]
 
-	uploadFiles(container_name, files, c)
+	uploadFiles(ctx, container_name, files, *c)
 
 }
 
-func uploadFiles(container string, files []string, c swift.Connection) {
-	wpauswiftcommons.CreatePublicContainer(container, c)
+func uploadFiles(ctx context.Context, container string, files []string, c swift.Connection) {
+	wpauswiftcommons.CreatePublicContainer(ctx, container, c)
 
 	for _, e := range files {
-		wpauswiftcommons.UploadFile(container, "", e, c)
+		wpauswiftcommons.UploadFile(ctx, container, "", e, c)
 	}
 }

--- a/src/project_pusher/project_pusher.go
+++ b/src/project_pusher/project_pusher.go
@@ -21,11 +21,11 @@ func main() {
 	}
 
 	if len(os.Args) < 3 {
-		fmt.Printf("Usage: %s project files...\n", os.Args[0])
+		fmt.Printf("Usage: %s [project] [files]...\n", os.Args[0])
 		os.Exit(1)
 	}
 
-	println("Starting objekt storage uploader")
+	fmt.Println("Starting objekt storage uploader")
 
 	var (
 		project = os.Args[1]
@@ -36,7 +36,8 @@ func main() {
 	// Authenticate
 	err := c.Authenticate(ctx)
 	if err != nil {
-		panic(err)
+		fmt.Printf("Error authenticating: %s\n", err)
+		os.Exit(1)
 	}
 
 	files := os.Args[2:]

--- a/src/project_pusher/project_pusher.go
+++ b/src/project_pusher/project_pusher.go
@@ -11,21 +11,20 @@ import (
 
 func main() {
 	ctx := context.Background()
-	// Create a connection
+	// Create a connection using openstack v3applicationcredential
 	c := &swift.Connection{
-		UserName: os.Getenv("SWIFT_API_USER"),
-		ApiKey:   os.Getenv("SWIFT_API_KEY"),
-		AuthUrl:  os.Getenv("SWIFT_AUTH_URL"),
-		Domain:   os.Getenv("SWIFT_API_DOMAIN"), // Name of the domain (v3 auth only)
-		Tenant:   os.Getenv("SWIFT_TENANT"),     // Name of the tenant (v2 auth only)
+		ApplicationCredentialId:     os.Getenv("OS_APPLICATION_CREDENTIAL_ID"),
+		ApplicationCredentialSecret: os.Getenv("OS_APPLICATION_CREDENTIAL_SECRET"),
+		AuthUrl:                     os.Getenv("OS_AUTH_URL"),
 	}
 
+	// We need at least two arguments. Project to upload to and file(s) to upload
 	if len(os.Args) < 3 {
 		fmt.Printf("Usage: %s [project] [files]...\n", os.Args[0])
 		os.Exit(1)
 	}
 
-	fmt.Println("Starting objekt storage uploader")
+	fmt.Println("Starting objekt storage uploader...")
 
 	var (
 		project = os.Args[1]


### PR DESCRIPTION
Updating project-pusher with proper formatting using "go fmt", use of github.com/ncw/swift/v2 with openstack application credentials (V3).  